### PR TITLE
Add optional salary field to job tracker and display on cards

### DIFF
--- a/client/src/components/add-prospect-form.tsx
+++ b/client/src/components/add-prospect-form.tsx
@@ -36,6 +36,7 @@ export function AddProspectForm({ onSuccess }: { onSuccess?: () => void }) {
       jobUrl: "",
       status: "Bookmarked",
       interestLevel: "Medium",
+      salary: null,
       notes: "",
     },
   });
@@ -156,6 +157,30 @@ export function AddProspectForm({ onSuccess }: { onSuccess?: () => void }) {
             )}
           />
         </div>
+
+        <FormField
+          control={form.control}
+          name="salary"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Target Salary (optional)</FormLabel>
+              <FormControl>
+                <Input
+                  type="number"
+                  placeholder="e.g. 120000"
+                  {...field}
+                  value={field.value ?? ""}
+                  onChange={(e) => {
+                    const val = e.target.value;
+                    field.onChange(val === "" ? null : Number(val));
+                  }}
+                  data-testid="input-salary"
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
 
         <FormField
           control={form.control}

--- a/client/src/components/edit-prospect-form.tsx
+++ b/client/src/components/edit-prospect-form.tsx
@@ -41,6 +41,7 @@ export function EditProspectForm({ prospect, onSuccess }: EditProspectFormProps)
       jobUrl: prospect.jobUrl ?? "",
       status: prospect.status as InsertProspect["status"],
       interestLevel: prospect.interestLevel as InsertProspect["interestLevel"],
+      salary: prospect.salary ?? null,
       notes: prospect.notes ?? "",
     },
   });
@@ -160,6 +161,30 @@ export function EditProspectForm({ prospect, onSuccess }: EditProspectFormProps)
             )}
           />
         </div>
+
+        <FormField
+          control={form.control}
+          name="salary"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Target Salary (optional)</FormLabel>
+              <FormControl>
+                <Input
+                  type="number"
+                  placeholder="e.g. 120000"
+                  {...field}
+                  value={field.value ?? ""}
+                  onChange={(e) => {
+                    const val = e.target.value;
+                    field.onChange(val === "" ? null : Number(val));
+                  }}
+                  data-testid="input-edit-salary"
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
 
         <FormField
           control={form.control}

--- a/client/src/components/prospect-card.tsx
+++ b/client/src/components/prospect-card.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import type { Prospect } from "@shared/schema";
 import { Button } from "@/components/ui/button";
-import { ExternalLink, Trash2, Pencil, Flame, ThumbsUp, Minus } from "lucide-react";
+import { ExternalLink, Trash2, Pencil, Flame, ThumbsUp, Minus, DollarSign } from "lucide-react";
 import { useMutation } from "@tanstack/react-query";
 import { apiRequest, queryClient } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
@@ -105,6 +105,15 @@ export function ProspectCard({ prospect }: { prospect: Prospect }) {
 
         <div className="flex items-center gap-1.5 flex-wrap">
           <InterestIndicator level={prospect.interestLevel} />
+          {prospect.salary != null && (
+            <span
+              className="inline-flex items-center gap-1 text-xs font-medium text-emerald-600 dark:text-emerald-400"
+              data-testid={`text-salary-${prospect.id}`}
+            >
+              <DollarSign className="w-3 h-3" />
+              {prospect.salary.toLocaleString()}
+            </span>
+          )}
         </div>
 
         {prospect.jobUrl && (

--- a/replit.md
+++ b/replit.md
@@ -50,6 +50,7 @@ shared/         - Shared TypeScript types and schemas
 - `job_url` (text, optional)
 - `status` (text): Bookmarked | Applied | Phone Screen | Interviewing | Offer | Rejected | Withdrawn
 - `interest_level` (text): High | Medium | Low
+- `salary` (integer, optional) - target salary in whole dollars
 - `notes` (text, optional)
 - `created_at` (timestamp with timezone)
 

--- a/server/__tests__/prospect-validation.test.ts
+++ b/server/__tests__/prospect-validation.test.ts
@@ -20,4 +20,69 @@ describe("prospect creation validation", () => {
     expect(result.valid).toBe(false);
     expect(result.errors).toContain("Role title is required");
   });
+
+  test("accepts a valid prospect without salary", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("accepts a valid prospect with salary", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+      salary: 120000,
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("accepts a prospect with null salary", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+      salary: null,
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("rejects a negative salary", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+      salary: -50000,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Salary must be a positive whole number");
+  });
+
+  test("rejects a non-integer salary", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+      salary: 120000.50,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Salary must be a positive whole number");
+  });
+
+  test("rejects zero salary", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+      salary: 0,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Salary must be a positive whole number");
+  });
 });

--- a/server/prospect-helpers.ts
+++ b/server/prospect-helpers.ts
@@ -39,6 +39,12 @@ export function validateProspect(data: Record<string, unknown>): { valid: boolea
     }
   }
 
+  if (data.salary !== undefined && data.salary !== null) {
+    if (typeof data.salary !== "number" || !Number.isInteger(data.salary) || data.salary <= 0) {
+      errors.push("Salary must be a positive whole number");
+    }
+  }
+
   return { valid: errors.length === 0, errors };
 }
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -40,6 +40,18 @@ export async function registerRoutes(
     if (body.jobUrl !== undefined) updates.jobUrl = body.jobUrl;
     if (body.notes !== undefined) updates.notes = body.notes;
 
+    if (body.salary !== undefined) {
+      if (body.salary === null) {
+        updates.salary = null;
+      } else {
+        const sal = Number(body.salary);
+        if (!Number.isInteger(sal) || sal <= 0) {
+          return res.status(400).json({ message: "Salary must be a positive whole number" });
+        }
+        updates.salary = sal;
+      }
+    }
+
     if (body.status !== undefined) {
       if (!STATUSES.includes(body.status)) {
         return res.status(400).json({ message: `Status must be one of: ${STATUSES.join(", ")}` });

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, serial, text, timestamp } from "drizzle-orm/pg-core";
+import { pgTable, serial, text, timestamp, integer } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
@@ -21,6 +21,7 @@ export const prospects = pgTable("prospects", {
   jobUrl: text("job_url"),
   status: text("status").notNull().default("Bookmarked"),
   interestLevel: text("interest_level").notNull().default("Medium"),
+  salary: integer("salary"),
   notes: text("notes"),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
 });
@@ -34,6 +35,7 @@ export const insertProspectSchema = createInsertSchema(prospects).omit({
   status: z.enum(STATUSES).default("Bookmarked"),
   interestLevel: z.enum(INTEREST_LEVELS).default("Medium"),
   jobUrl: z.string().optional().nullable(),
+  salary: z.number().int().positive("Salary must be a positive number").optional().nullable(),
   notes: z.string().optional().nullable(),
 });
 


### PR DESCRIPTION
Adds an optional numeric salary field to prospects, including frontend input, backend validation, and display on job cards.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 6f739901-6255-41bb-b332-e5ee8dbb67dd
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Event-Id: bdb3f1c8-060b-48d4-828f-636ee24ec673
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/467a6a13-7f6f-464e-b328-bb801f9787fb/6f739901-6255-41bb-b332-e5ee8dbb67dd/KjKWSnb
Replit-Helium-Checkpoint-Created: true